### PR TITLE
update(readme): fix github url in lazy install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ vim.highlight.priorities.treesitter = 100 -- default is 100
 
 ```lua
 {
-  "noetrevino/no-go.nvim",
+  "thenoetrevino/no-go.nvim",
   dependencies = { "nvim-treesitter/nvim-treesitter" },
   ft = "go",
   opts = {


### PR DESCRIPTION
This pull request updates the plugin source in the documentation to reflect the correct GitHub username. This ensures users will install the plugin from the intended repository.

- Documentation update:
  * Changed the plugin reference in the example code in `README.md` from `"noetrevino/no-go.nvim"` to `"thenoetrevino/no-go.nvim"` to match the correct repository.


P.S. Thanks for the great addition to the go/nvim ecosystem!