### PR TITLE
fix: remove statement_list from error query

### DIFF
--- a/lua/no-go/queries.lua
+++ b/lua/no-go/queries.lua
@@ -1,15 +1,13 @@
 local M = {}
 
 M.error_query = [[
-(
-  (if_statement
-    condition: (binary_expression
-      left: (identifier) @err_identifier)
-    consequence: (block
-      (statement_list
-        (return_statement
-          (expression_list
-            (identifier) @return_identifier)?)))) @collapse_block) @if_statement
+(if_statement
+  condition: (binary_expression
+    left: (identifier) @err_identifier)
+  consequence: (block
+    (return_statement
+      (expression_list
+        (identifier) @return_identifier)?)) @collapse_block) @if_statement
 ]]
 
 M.import_query = [[


### PR DESCRIPTION
The Go treesitter grammar no longer has a statement_list node. Statements are now direct children of block nodes.

This fixes the 'Failed to parse error query' error that occurs when opening Go files.

Closes #24 